### PR TITLE
Revertir el Martes: Abrir registro para las que tienen cuenta

### DIFF
--- a/src/lib/validators/ofmi.ts
+++ b/src/lib/validators/ofmi.ts
@@ -9,12 +9,6 @@ export function validateOFMIOpenAndCloseTime(
     role,
   }: { registrationTime: Date; role: ParticipationRole },
 ): ValidationResult {
-  if (ofmi.registrationOpenTime.getTime() > registrationTime.getTime()) {
-    return {
-      ok: false,
-      message: `Las inscripciones para esta OFMI aun no han abierto.`,
-    };
-  }
   if (role === "VOLUNTEER") {
     // Vamos a darles todo el año para registrarse
     if (

--- a/src/pages/api/ofmi/upsertParticipation.ts
+++ b/src/pages/api/ofmi/upsertParticipation.ts
@@ -87,7 +87,7 @@ async function upsertParticipationHandler(
       field: "Fechas de registro OFMI",
       result: validateOFMIOpenAndCloseTime(ofmi, {
         role,
-        registrationTime: requestStartTime,
+        registrationTime: authUser.createdAt,
       }),
     },
   ];

--- a/src/pages/registro.tsx
+++ b/src/pages/registro.tsx
@@ -17,13 +17,9 @@ import { X_USER_AUTH_EMAIL_HEADER } from "@/lib/auth";
 export default function RegistroPage({
   ofmiEdition,
   participationJSON,
-  registrationClosingTime,
   role,
 }: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
-  if (
-    ofmiEdition == null ||
-    (registrationClosingTime && registrationClosingTime < Date.now())
-  ) {
+  if (ofmiEdition == null) {
     const errorMsg = ofmiEdition ? "El registro de la OFMI ha finalizado." : "";
     return (
       <div className="flex w-full items-center justify-center">

--- a/src/pages/signup.mdx
+++ b/src/pages/signup.mdx
@@ -1,0 +1,3 @@
+# La creación de cuentas estará fuera de servicio unos días
+
+<div align="center">Vuelva pronto</div>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,5 +1,0 @@
-import SignUp from "@/components/signup";
-
-export default function LoginPage(): JSX.Element {
-  return <SignUp />;
-}


### PR DESCRIPTION
Vamos a permitir que las personas que tienen cuenta pero no llenaron el registro lo llenen de aquí al lunes.

Este cambio es temporal y debe revertirse. 

* Asumimos que el registration time es cuando crearon su cuenta. Esto va a pasar el check del backend
* Se deshabilita temporalmente crear una cuenta. Para evitar confusiones.