### PR TITLE
disclosure button availabe for all viewports

### DIFF
--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -31,7 +31,7 @@ export const Navbar = (): JSX.Element => {
         <>
           <div className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
             <div className="relative flex h-16 items-center justify-between">
-              <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
+              <div className="absolute inset-y-0 left-0 flex items-center ">
                 {/* Mobile menu button */}
                 <Disclosure.Button className="relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
                   <span className="absolute -inset-0.5" />
@@ -43,7 +43,7 @@ export const Navbar = (): JSX.Element => {
                   )}
                 </Disclosure.Button>
               </div>
-              <div className="flex flex-1 items-center justify-center sm:items-stretch sm:justify-start">
+              <div className="flex w-20 items-end justify-end ">
                 <div className="flex flex-shrink-0 items-center">
                   <a key="index-icon" href="/">
                     <Image
@@ -55,7 +55,7 @@ export const Navbar = (): JSX.Element => {
                     />
                   </a>
                 </div>
-                <div className="hidden sm:ml-6 sm:block">
+                {/*<div className="hidden sm:ml-6 sm:block">
                   <div className="flex items-center space-x-4">
                     {Object.entries(navigation).map(([name, href]) => (
                       <a
@@ -73,7 +73,7 @@ export const Navbar = (): JSX.Element => {
                       </a>
                     ))}
                   </div>
-                </div>
+                </div>*/}
               </div>
               {session.status === "authenticated" ? (
                 <ProfileDropdown />
@@ -85,8 +85,8 @@ export const Navbar = (): JSX.Element => {
             </div>
           </div>
 
-          <Disclosure.Panel className="sm:hidden">
-            <div className="space-y-1 px-2 pb-3 pt-2">
+          <Disclosure.Panel className="">
+            <div className="relative space-y-1 px-2 pb-3 pt-2">
               {Object.entries(navigation).map(([name, href]) => (
                 <Disclosure.Button
                   key={name}


### PR DESCRIPTION
Using disclousure button in navbar 
## Mobile devices 
<img width="1919" height="1000" alt="image" src="https://github.com/user-attachments/assets/55a432e2-505c-4525-8429-d970b9381982" />

## Desktop and tablets

<img width="1919" height="1000" alt="image" src="https://github.com/user-attachments/assets/01e8848e-62a4-40f5-860d-0939dbb44cc2" />
